### PR TITLE
fix: added argument to include prettier in config

### DIFF
--- a/utils/renderEslint.ts
+++ b/utils/renderEslint.ts
@@ -36,7 +36,7 @@ export default function renderEslint(rootDir, { needsTypeScript, needsCypress, n
     // we currently don't support other style guides
     styleGuide: 'default',
     hasTypeScript: needsTypeScript,
-
+    needsPrettier: true,
     additionalConfig,
     additionalDependencies
   })


### PR DESCRIPTION
re #119

Creation of `eslint-config` is delegated to the external function  `createESLintConfig()` from a package called `@vue/create-eslint-config`, which was missing its argument to include `prettier` config.