### PR TITLE
refactor: change minimist to parseArgs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
-import minimist from 'minimist'
+import { parseArgs } from 'node:util'
 import prompts from 'prompts'
 import { red, green, bold, yellow } from 'kolorist'
 
@@ -84,26 +84,33 @@ async function init() {
   // --tanStackQuery
   // --tailwind
   // --force (for force overwriting)
-  const argv = minimist(process.argv.slice(2), {
-    alias: {
-      typescript: ['ts'],
-      'with-tests': ['tests'],
-      router: ['vue-router']
-    },
-    string: ['_'],
-    // all arguments are treated as booleans
-    boolean: true
+  const args = process.argv.slice(2)
+
+  // alias is not supported by parseArgs
+  const options = {
+    typescript: { type: 'boolean' },
+    ts: { type: 'boolean' },
+    'with-tests': { type: 'boolean' },
+    tests: { type: 'boolean' },
+    'vue-router': { type: 'boolean' },
+    router: { type: 'boolean' }
+  } as const
+
+  const { values: argv } = parseArgs({
+    args,
+    options,
+    strict: false
   })
 
   // if any of the feature flags is set, we would skip the feature prompts
   const isFeatureFlagsUsed =
     typeof (
       argv.default ??
-      argv.ts ??
+      (argv.ts || argv.typescript) ??
       argv.jsx ??
-      argv.router ??
+      (argv.router || argv['vue-router']) ??
       argv.pinia ??
-      argv.tests ??
+      (argv.tests || argv['with-tests']) ??
       argv.vitest ??
       argv.cypress ??
       argv.nightwatch ??
@@ -116,7 +123,7 @@ async function init() {
       argv.tailwind
     ) === 'boolean'
 
-  let targetDir = argv._[0]
+  let targetDir = args[0]
   const defaultProjectName = !targetDir ? 'vue-project' : targetDir
 
   const forceOverwrite = argv.force

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "husky": "^9.0.11",
         "kolorist": "^1.8.0",
         "lint-staged": "^15.2.2",
-        "minimist": "^1.2.8",
         "npm-run-all2": "^6.1.2",
         "prettier": "^3.2.5",
         "prompts": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "husky": "^9.0.11",
     "kolorist": "^1.8.0",
     "lint-staged": "^15.2.2",
-    "minimist": "^1.2.8",
     "npm-run-all2": "^6.1.2",
     "prettier": "^3.2.5",
     "prompts": "^2.4.2",


### PR DESCRIPTION
# Pull Request

## Description
1. Remove minimist package from package.json
2. index.ts > Migrate minimist related code to parseArgs
3. Delete minimist from LICENSE.

## Related Issue
re #214 

## Checklist

- [x] All existing tests pass
- [x] Code comments added/updated

## Notes for Reviewers
1. **alias** is not supported by **parseArgs**. It has `short {string}` A single character alias for the option, but it's not matching our case.
2. **strict** is set to **false** because it will trigger a console error when an argument is passed that is not defined in the options.
