### PR TITLE
docs: delete vue ts related information

### DIFF
--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -4,14 +4,7 @@ const sfcTypeSupportDoc = [
   '',
   '## Type Support for `.vue` Imports in TS',
   '',
-  'TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin) to make the TypeScript language service aware of `.vue` types.',
-  '',
-  "If the standalone TypeScript plugin doesn't feel fast enough to you, Volar has also implemented a [Take Over Mode](https://github.com/johnsoncodehk/volar/discussions/471#discussioncomment-1361669) that is more performant. You can enable it by the following steps:",
-  '',
-  '1. Disable the built-in TypeScript Extension',
-  "    1) Run `Extensions: Show Built-in Extensions` from VSCode's command palette",
-  '    2) Find `TypeScript and JavaScript Language Features`, right click and select `Disable (Workspace)`',
-  '2. Reload the VSCode window by running `Developer: Reload Window` from the command palette.',
+  'TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking.In editors, we need[Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) to make the TypeScript language service aware of `.vue` types.',
   ''
 ].join('\n')
 
@@ -40,7 +33,7 @@ This template should help get you started developing with Vue 3 in Vite.
 
 ## Recommended IDE Setup
 
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur) + [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin).
+[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
 ${needsTypeScript ? sfcTypeSupportDoc : ''}
 ## Customize configuration
 


### PR DESCRIPTION
# Pull Request

## Description
- [x] delete plugin related information from **utils/generateReadme.ts**
- [x] delete "take over mode" information from  **utils/generateReadme.ts** (bacause takeover mode is depricated https://github.com/vuejs/language-tools/releases/tag/v2.0.0)

## Related Issue
https://github.com/vuejs/create-vue/pull/458

## Checklist

<!-- Check all applicable items and provide details if necessary -->

- [ ] Tests added (if applicable)
- [x] All existing tests pass
- [x] Documentation updated
- [x] Code follows project coding standards
- [ ] Code comments added/updated