### PR TITLE
ci: avoid double execution of ci on renovate PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           path: outfile.cjs
           key: ${{ github.sha }}-${{ hashFiles('package-lock.json') }}
   test:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     needs: build
     strategy:
       matrix:


### PR DESCRIPTION
# Pull Request

## Description

ci: avoid double execution of ci on renovate PRs

https://github.com/vuejs/create-vue/commit/92ff300ccdab0949bdd971f14e2908bc62e693c2

This ensures that the job or step it's attached to will only run if the workflow was triggered by a push event or if the pull request event originated from a forked repository.

