### PR TITLE
fix(playwright): use npm run to start the server on default port

### DIFF
--- a/template/config/playwright/playwright.config.js
+++ b/template/config/playwright/playwright.config.js
@@ -34,7 +34,7 @@ export default defineConfig({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
+    baseURL: process.env.CI ? 'http://localhost:4173' : 'http://localhost:5173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -103,8 +103,8 @@ export default defineConfig({
      * Use the preview server on CI for more realistic testing.
      * Playwright will re-use the local server if there is already a dev-server running.
      */
-    command: process.env.CI ? 'vite preview --port 5173' : 'vite dev',
-    port: 5173,
+    command: process.env.CI ? 'npm run preview' : 'npm run dev',
+    port: process.env.CI ? 4173 : 5173,
     reuseExistingServer: !process.env.CI
   }
 })


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a brief description of the changes introduced by this pull request -->

## Related Issue

re: https://github.com/vuejs/create-vue/commit/cf3f7a7ea7813ad0bdaa7794ddc57a615706edf3
<!-- If applicable, reference the GitHub issue that this pull request addresses. Use the syntax "Resolves #issue_number" to automatically close the linked issue when the pull request is merged. -->

